### PR TITLE
Correct full-duplex transaction in ESP32 as per documentation.

### DIFF
--- a/src/esp32/esp32_spi_master.c
+++ b/src/esp32/esp32_spi_master.c
@@ -264,7 +264,10 @@ static void esp32_spi_get_rx_data(spi_dev_t *dev, uint8_t *data, size_t skip,
       if (skip > 0) {
         skip--;
       } else {
-        data[i++] = byte;
+        if (NULL != data) {
+          data[i] = byte;
+        }
+        ++i;
       }
       w >>= 8;
     }
@@ -314,7 +317,9 @@ static bool mgos_spi_run_txn_fd(struct mgos_spi *c, const void *tx_data,
     }
     esp32_spi_get_rx_data(dev, rxdp, 0, dlen);
     txdp += dlen;
-    rxdp += dlen;
+    if (NULL != rxdp) {
+      rxdp += dlen;
+    }
   }
 
   return true;

--- a/src/esp32/esp32_spi_master.c
+++ b/src/esp32/esp32_spi_master.c
@@ -264,9 +264,7 @@ static void esp32_spi_get_rx_data(spi_dev_t *dev, uint8_t *data, size_t skip,
       if (skip > 0) {
         skip--;
       } else {
-        if (NULL != data) {
-          data[i] = byte;
-        }
+        if (data != NULL) data[i] = byte;
         ++i;
       }
       w >>= 8;
@@ -317,9 +315,7 @@ static bool mgos_spi_run_txn_fd(struct mgos_spi *c, const void *tx_data,
     }
     esp32_spi_get_rx_data(dev, rxdp, 0, dlen);
     txdp += dlen;
-    if (NULL != rxdp) {
-      rxdp += dlen;
-    }
+    if (rxdp != NULL) rxdp += dlen;
   }
 
   return true;

--- a/src/stm32/stm32_spi_master_gspi.c
+++ b/src/stm32/stm32_spi_master_gspi.c
@@ -102,6 +102,7 @@ bool stm32_gspi_run_txn_fd(struct mgos_spi *c, const struct mgos_spi_txn *txn) {
   size_t len = txn->fd.len;
   const uint8_t *tx_data = (const uint8_t *) txn->hd.tx_data;
   uint8_t *rx_data = (uint8_t *) txn->fd.rx_data;
+  bool discard_rx = (txn->fd.rx_data == NULL);
   volatile uint8_t *drp = (volatile uint8_t *) &c->regs->DR;
 
   if (c->debug) {
@@ -128,7 +129,9 @@ bool stm32_gspi_run_txn_fd(struct mgos_spi *c, const struct mgos_spi_txn *txn) {
       if (c->debug) {
         LOG(LL_DEBUG, ("read 0x%02x", byte));
       }
-      *rx_data++ = byte;
+      if(!discard_rx) {
+        *rx_data++ = byte;
+      }
     }
     len--;
   }

--- a/src/stm32/stm32_spi_master_gspi.c
+++ b/src/stm32/stm32_spi_master_gspi.c
@@ -129,9 +129,7 @@ bool stm32_gspi_run_txn_fd(struct mgos_spi *c, const struct mgos_spi_txn *txn) {
       if (c->debug) {
         LOG(LL_DEBUG, ("read 0x%02x", byte));
       }
-      if(!discard_rx) {
-        *rx_data++ = byte;
-      }
+      if (!discard_rx) *rx_data++ = byte;
     }
     len--;
   }


### PR DESCRIPTION
Do the same for STM32 (untested).

Signed-off-by: Sergio R. Caprile